### PR TITLE
Multiple scan interval

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -28,4 +28,7 @@ yahoofinance:
     - ^SSMI
     - symbol: EMIM.L
       target_currency: EUR
+      scan_interval: 30
     - symbol: AAPL
+    - symbol: USDINR=X
+      scan_interval: 45

--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -24,6 +24,7 @@ yahoofinance:
     - symbol: IDFCBANK.BO
     - symbol: baba
       target_currency: inr
+      scan_interval: 30
     - ^SSMI
     - symbol: EMIM.L
       target_currency: EUR

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
 	"extensions": [
 		"ms-python.python",
 		"ms-python.vscode-pylance",
-		"esbenp.prettier-vscode"
+		"esbenp.prettier-vscode",
+		"littlefoxteam.vscode-python-test-adapter"
 	],
 	"settings": {
 		"files.eol": "\n",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,13 +8,13 @@
 			"module": "homeassistant",
 			"justMyCode": false,
 			"args": [
-				"--debug",
 				"-c",
 				"/config"
 			],
 			"serverReadyAction": {
 				"action": "openExternally"
-			}
+			},
+			"console": "integratedTerminal"
 		}
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,4 +4,9 @@
     "editor.formatOnSave": true,
     "files.trimTrailingWhitespace": true,
     "git.ignoreLimitWarning": true,
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
 }

--- a/README.md
+++ b/README.md
@@ -61,14 +61,17 @@ icon: mdi:trending-up
 
 The `dividendDate` is in ISO format (YYYY-MM-DD) and can be `null`.
 
-
 ## Optional Configuration
 
+### Integration
+
 - Data fetch interval can be adjusted by specifying the `scan_interval` setting whose default value is 6 hours and the minimum value is 30 seconds.
+
   ```yaml
   scan_interval:
     hours: 4
   ```
+
   You can disable automatic update by passing `None` for `scan_interval`.
 
 - Trending icons (trending-up, trending-down or trending-neutral) can be displayed instead of currency based icon by specifying `show_trending_icon`.
@@ -76,18 +79,10 @@ The `dividendDate` is in ISO format (YYYY-MM-DD) and can be `null`.
   show_trending_icon: true
   ```
 - All numeric values are by default rounded to 2 places of decimal. This can be adjusted by the `decimal_places` setting. A value of 0 will return in integer values and -1 will suppress rounding.
+
   ```yaml
   decimal_places: 3
   ```
-- An alternate target currency can be specified for a symbol using the extended declaration format. Here, the symbol EMIM.L is reported in USD but will be presented in EUR. The conversion would be based on the value of the symbol USDEUR=X.
-
-  ```yaml
-  symbols:
-    - symbol: EMIM.L
-      target_currency: EUR
-    ```
-
-  If data for the target currency is not found, then the display will remain in original currency. The conversion is only applied on the attributes representing prices.
 
 - The fifty_day, post, pre and two_hundred attributes can be suppressed as following. They are included by default.
   ```yaml
@@ -97,13 +92,36 @@ The `dividendDate` is in ISO format (YYYY-MM-DD) and can be `null`.
   include_two_hundred_day_values: false
   ```
 
+### Symbol
+
+- An alternate target currency can be specified for a symbol using the extended declaration format. Here, the symbol EMIM.L is reported in USD but will be presented in EUR. The conversion would be based on the value of the symbol USDEUR=X.
+
+  ```yaml
+  symbols:
+    - symbol: EMIM.L
+      target_currency: EUR
+  ```
+
+  If data for the target currency is not found, then the display will remain in original currency. The conversion is only applied on the attributes representing prices.
+
+- The data fetch interval can be fine tuned at symbol level. By default, the `scan_interval` from the integration is used. The minimum value is still 30 seconds. Symbols with the same `scan_interval` are grouped together and loaded through one data coordinator.
+
+  If conversion data needs to be loaded, then that too will get added to the same coordinator. However, if conversion symbol is found in another coordinator, then that will get used.
+
+  ```yaml
+  scan_interval:
+    hours: 4
+  ```
+
 ## Examples
+
 - The symbol can also represent a financial index such as [this](https://finance.yahoo.com/world-indices/).
 
   ```yaml
   symbols:
     - ^SSMI
   ```
+
 - Yahoo also provides currency conversion as a symbol.
   ```yaml
   symbols:
@@ -133,7 +151,6 @@ The `dividendDate` is in ISO format (YYYY-MM-DD) and can be `null`.
 # Services
 
 The component exposes the service `yahoofinance.refresh_symbols` which can be used to refresh all the data.
-
 
 # Breaking Changes
 

--- a/custom_components/yahoofinance/__init__.py
+++ b/custom_components/yahoofinance/__init__.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Final
 
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
@@ -34,15 +33,15 @@ from .const import (
     DEFAULT_CONF_INCLUDE_PRE_VALUES,
     DEFAULT_CONF_INCLUDE_TWO_HUNDRED_DAY_VALUES,
     DEFAULT_CONF_SHOW_TRENDING_ICON,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     HASS_DATA_CONFIG,
     HASS_DATA_COORDINATORS,
+    MINIMUM_SCAN_INTERVAL,
     SERVICE_REFRESH,
 )
 
 _LOGGER = logging.getLogger(__name__)
-DEFAULT_SCAN_INTERVAL: Final = timedelta(hours=6)
-MINIMUM_SCAN_INTERVAL: Final = timedelta(seconds=30)
 
 
 BASIC_SYMBOL_SCHEMA = vol.All(cv.string, vol.Upper)
@@ -107,8 +106,13 @@ class SymbolDefinition:
     target_currency: str | None = None
     scan_interval: timedelta | None = None
 
-    def __init__(self, symbol: str, **kwargs) -> None:
-        """Create a new symbol definition."""
+    def __init__(self, symbol: str, **kwargs: any) -> None:
+        """Create a new symbol definition.
+
+        ### Parameters
+            symbol(str): The symbol
+            **scan_interval (time_delta): The symbol scan interval
+        """
         self.symbol = symbol
 
         if "target_currency" in kwargs:

--- a/custom_components/yahoofinance/__init__.py
+++ b/custom_components/yahoofinance/__init__.py
@@ -170,7 +170,9 @@ def normalize_input_symbols(
                     SymbolDefinition(
                         symbol,
                         target_currency=value.get(CONF_TARGET_CURRENCY),
-                        scan_interval=value.get(CONF_SCAN_INTERVAL),
+                        scan_interval=parse_scan_interval(
+                            value.get(CONF_SCAN_INTERVAL)
+                        ),
                     )
                 )
 

--- a/custom_components/yahoofinance/__init__.py
+++ b/custom_components/yahoofinance/__init__.py
@@ -36,7 +36,7 @@ from .const import (
     DEFAULT_CONF_SHOW_TRENDING_ICON,
     DOMAIN,
     HASS_DATA_CONFIG,
-    HASS_DATA_COORDINATOR,
+    HASS_DATA_COORDINATORS,
     SERVICE_REFRESH,
 )
 
@@ -53,6 +53,9 @@ COMPLEX_SYMBOL_SCHEMA = vol.All(
         {
             vol.Required("symbol"): BASIC_SYMBOL_SCHEMA,
             vol.Optional(CONF_TARGET_CURRENCY): BASIC_SYMBOL_SCHEMA,
+            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.Any(
+                "none", "None", cv.positive_time_period
+            ),
         }
     ),
 )
@@ -101,16 +104,21 @@ class SymbolDefinition:
     """Symbol definition."""
 
     symbol: str
-    target_currency: str
+    target_currency: str | None = None
+    scan_interval: timedelta | None = None
 
-    def __init__(self, symbol: str, target_currency: str | None = None) -> None:
+    def __init__(self, symbol: str, **kwargs) -> None:
         """Create a new symbol definition."""
         self.symbol = symbol
-        self.target_currency = target_currency
+
+        if "target_currency" in kwargs:
+            self.target_currency = kwargs["target_currency"]
+        if "scan_interval" in kwargs:
+            self.scan_interval = kwargs["scan_interval"]
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"{self.symbol},{self.target_currency}"
+        return f"{self.symbol},{self.target_currency},{self.scan_interval}"
 
     def __eq__(self, other: any) -> bool:
         """Return the comparison."""
@@ -118,11 +126,12 @@ class SymbolDefinition:
             isinstance(other, SymbolDefinition)
             and self.symbol == other.symbol
             and self.target_currency == other.target_currency
+            and self.scan_interval == other.scan_interval
         )
 
     def __hash__(self) -> int:
         """Make hashable."""
-        return hash((self.symbol, self.target_currency))
+        return hash((self.symbol, self.target_currency, self.scan_interval))
 
 
 def parse_scan_interval(scan_interval: timedelta | str) -> timedelta:
@@ -141,7 +150,9 @@ def parse_scan_interval(scan_interval: timedelta | str) -> timedelta:
     return scan_interval
 
 
-def normalize_input(defined_symbols: list) -> tuple[list[str], list[SymbolDefinition]]:
+def normalize_input_symbols(
+    defined_symbols: list,
+) -> tuple[list[str], list[SymbolDefinition]]:
     """Normalize input and remove duplicates."""
     symbols = set()
     symbol_definitions: list[SymbolDefinition] = []
@@ -156,7 +167,11 @@ def normalize_input(defined_symbols: list) -> tuple[list[str], list[SymbolDefini
             if symbol not in symbols:
                 symbols.add(symbol)
                 symbol_definitions.append(
-                    SymbolDefinition(symbol, value.get(CONF_TARGET_CURRENCY))
+                    SymbolDefinition(
+                        symbol,
+                        target_currency=value.get(CONF_TARGET_CURRENCY),
+                        scan_interval=value.get(CONF_SCAN_INTERVAL),
+                    )
                 )
 
     return (list(symbols), symbol_definitions)
@@ -167,7 +182,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     domain_config = config.get(DOMAIN, {})
     defined_symbols = domain_config.get(CONF_SYMBOLS, [])
 
-    symbols, symbol_definitions = normalize_input(defined_symbols)
+    symbol_definitions: list[SymbolDefinition]
+    symbols, symbol_definitions = normalize_input_symbols(defined_symbols)
     domain_config[CONF_SYMBOLS] = symbol_definitions
 
     scan_interval = parse_scan_interval(domain_config.get(CONF_SCAN_INTERVAL))
@@ -175,24 +191,48 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # Populate parsed value into domain_config
     domain_config[CONF_SCAN_INTERVAL] = scan_interval
 
-    coordinator = YahooSymbolUpdateCoordinator(symbols, hass, scan_interval)
+    # Group symbols by scan_interval
+    symbols_by_scan_interval: dict[timedelta, list[str]] = {}
+    for symbol in symbol_definitions:
+        # Use integration level scan_interval if none defined
+        if symbol.scan_interval is None:
+            symbol.scan_interval = scan_interval
 
-    # Refresh coordinator to get initial symbol data
-    _LOGGER.info(
-        "Requesting data from coordinator with update interval of %s.", scan_interval
-    )
-    await coordinator.async_refresh()
+        if symbol.scan_interval in symbols_by_scan_interval:
+            symbols_by_scan_interval[symbol.scan_interval].append(symbol.symbol)
+        else:
+            symbols_by_scan_interval[symbol.scan_interval] = [symbol.symbol]
+
+    _LOGGER.info("Total %d unique scan intervals", len(symbols_by_scan_interval))
+
+    coordinators: dict[timedelta, YahooSymbolUpdateCoordinator] = {}
+    for key_scan_interval, symbols in symbols_by_scan_interval.items():
+        _LOGGER.info(
+            "Creating coordinator with scan_interval %s for symbols %s",
+            key_scan_interval,
+            symbols,
+        )
+        coordinator = YahooSymbolUpdateCoordinator(symbols, hass, key_scan_interval)
+        coordinators[key_scan_interval] = coordinator
+
+        _LOGGER.info(
+            "Requesting initial data from coordinator with update interval of %s.",
+            key_scan_interval,
+        )
+        await coordinator.async_refresh()
 
     # Pass down the coordinator and config to platforms.
     hass.data[DOMAIN] = {
-        HASS_DATA_COORDINATOR: coordinator,
+        HASS_DATA_COORDINATORS: coordinators,
         HASS_DATA_CONFIG: domain_config,
     }
 
     async def handle_refresh_symbols(_call) -> None:
         """Refresh symbol data."""
         _LOGGER.info("Processing refresh_symbols")
-        await coordinator.async_request_refresh()
+
+        for coordinator in coordinators.values():
+            await coordinator.async_refresh()
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -15,7 +15,7 @@ ATTR_DIVIDEND_DATE: Final = "dividendDate"
 
 # Hass data
 HASS_DATA_CONFIG: Final = "config"
-HASS_DATA_COORDINATOR: Final = "coordinator"
+HASS_DATA_COORDINATORS: Final = "coordinators"
 
 # JSON data pieces
 DATA_CURRENCY_SYMBOL: Final = "currency"
@@ -46,9 +46,10 @@ DEFAULT_CONF_SHOW_TRENDING_ICON: Final = False
 
 DEFAULT_NUMERIC_DATA_GROUP: Final = "default"
 
-# Data keys grouped into categories. The values for the categories (except for DEFAULT_NUMERIC_DATA_GROUP)
-# can be conditionally pulled into attributes. The first value of the set is the key and the second
-# boolean value indicates if the attribute is a currency.
+# Data keys grouped into categories. The values for the categories except for
+# DEFAULT_NUMERIC_DATA_GROUP can be conditionally pulled into attributes. The
+# first value of the set is the key and the second boolean value indicates if
+# the attribute is a currency.
 NUMERIC_DATA_GROUPS: Final = {
     DEFAULT_NUMERIC_DATA_GROUP: [
         ("averageDailyVolume10Day", False),

--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Final
 
 # Additional attributes exposed by the sensor
@@ -116,6 +117,9 @@ DEFAULT_CURRENCY_SYMBOL: Final = "$"
 DEFAULT_ICON: Final = "mdi:currency-usd"
 DOMAIN: Final = "yahoofinance"
 SERVICE_REFRESH: Final = "refresh_symbols"
+
+DEFAULT_SCAN_INTERVAL: Final = timedelta(hours=6)
+MINIMUM_SCAN_INTERVAL: Final = timedelta(seconds=30)
 
 CURRENCY_CODES: Final = {
     "bdt": "৳",

--- a/custom_components/yahoofinance/coordinator.py
+++ b/custom_components/yahoofinance/coordinator.py
@@ -107,12 +107,12 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator):
         """Get the update interval for the next async_track_point_in_utc_time call."""
         if self.last_update_success:
             return self._update_interval
-        else:
-            _LOGGER.warning(
-                "Error obtaining data, retrying in %d seconds.",
-                FAILURE_ASYNC_REQUEST_REFRESH,
-            )
-            return self._failure_update_interval
+
+        _LOGGER.warning(
+            "Error obtaining data, retrying in %d seconds.",
+            FAILURE_ASYNC_REQUEST_REFRESH,
+        )
+        return self._failure_update_interval
 
     @callback
     def _schedule_refresh(self) -> None:
@@ -222,7 +222,7 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator):
         else:
             _LOGGER.debug("Data = %s", result)
 
-        _LOGGER.info("All symbols updated")
+        _LOGGER.info("Data updated [interval=%s]", self._update_interval)
         return data
 
     def process_json_result(self, result) -> tuple[bool, dict]:

--- a/custom_components/yahoofinance/sensor.py
+++ b/custom_components/yahoofinance/sensor.py
@@ -219,7 +219,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
             and super().available
             and not self._waiting_on_conversion
         )
-        _LOGGER.info("%s available=%s", self._symbol, value)
+        _LOGGER.debug("%s available=%s", self._symbol, value)
         return value
 
     @callback
@@ -310,7 +310,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
         self._original_currency = currency or financial_currency or DEFAULT_CURRENCY
 
     def update_properties(self) -> None:
-        """Update local fields."""
+        """Update local fields. This is also used in unit testing."""
 
         data = self.coordinator.data
         if data is None:

--- a/custom_components/yahoofinance/sensor.py
+++ b/custom_components/yahoofinance/sensor.py
@@ -158,7 +158,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
             self._target_currency,
         )
 
-        self._update_properties()
+        self.update_properties()
 
     @staticmethod
     def safe_convert(value: float | None, conversion: float | None) -> float | None:
@@ -225,7 +225,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._update_properties()
+        self.update_properties()
         super()._handle_coordinator_update()
 
     def _round(self, value: float | None) -> float | int | None:
@@ -309,7 +309,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
 
         self._original_currency = currency or financial_currency or DEFAULT_CURRENCY
 
-    def _update_properties(self) -> None:
+    def update_properties(self) -> None:
         """Update local fields."""
 
         data = self.coordinator.data

--- a/custom_components/yahoofinance/sensor.py
+++ b/custom_components/yahoofinance/sensor.py
@@ -6,9 +6,8 @@ https://github.com/iprak/yahoofinance
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 import logging
-from timeit import default_timer as timer
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -17,8 +16,10 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.yahoofinance import SymbolDefinition, convert_to_float
@@ -51,7 +52,7 @@ from .const import (
     DEFAULT_NUMERIC_DATA_GROUP,
     DOMAIN,
     HASS_DATA_CONFIG,
-    HASS_DATA_COORDINATOR,
+    HASS_DATA_COORDINATORS,
     NUMERIC_DATA_GROUPS,
     PERCENTAGE_DATA_KEYS_NEEDING_MULTIPLICATION,
 )
@@ -60,20 +61,30 @@ _LOGGER = logging.getLogger(__name__)
 ENTITY_ID_FORMAT = SENSOR_DOMAIN + "." + DOMAIN + "_{}"
 
 
-async def async_setup_platform(hass, _config, async_add_entities, _discovery_info=None):
+async def async_setup_platform(
+    hass: HomeAssistant,
+    _config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    _discovery_info: DiscoveryInfoType | None = None,
+):
     """Set up the Yahoo Finance sensor platform."""
 
-    coordinator = hass.data[DOMAIN][HASS_DATA_COORDINATOR]
+    coordinators: dict[timedelta, YahooSymbolUpdateCoordinator] = hass.data[DOMAIN][
+        HASS_DATA_COORDINATORS
+    ]
     domain_config = hass.data[DOMAIN][HASS_DATA_CONFIG]
     symbol_definitions: list[SymbolDefinition] = domain_config[CONF_SYMBOLS]
 
     # We don't know the currency of a symbol so can't added conversion symbols upfront
 
     sensors = [
-        YahooFinanceSensor(hass, coordinator, symbol, domain_config)
+        YahooFinanceSensor(
+            hass, coordinators[symbol.scan_interval], symbol, domain_config
+        )
         for symbol in symbol_definitions
     ]
 
+    # We have already invoked async_refresh on coordinator, so don'tupdate_before_add
     async_add_entities(sensors, update_before_add=False)
     _LOGGER.info("Entities added for %s", [item.symbol for item in symbol_definitions])
 
@@ -81,6 +92,7 @@ async def async_setup_platform(hass, _config, async_add_entities, _discovery_inf
 class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
     """Represents a Yahoo finance entity."""
 
+    # pylint: disable=too-many-instance-attributes
     _currency = DEFAULT_CURRENCY
     _icon = DEFAULT_ICON
     _market_price = None
@@ -88,20 +100,23 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
     _target_currency = None
     _original_currency = None
     _last_available_timer = None
-    _waiting_on_converstion = False
+    _waiting_on_conversion = False
 
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_device_class = SensorDeviceClass.MONETARY
 
     def __init__(
         self,
-        hass,
+        hass: HomeAssistant,
         coordinator: YahooSymbolUpdateCoordinator,
         symbol_definition: SymbolDefinition,
-        domain_config,
+        domain_config: dict,
     ) -> None:
         """Initialize the YahooFinance entity."""
         super().__init__(coordinator)
+
+        # Entity.hass is only populated after async_add_entities, use local reference to hass
+        self._hass = hass
 
         symbol = symbol_definition.symbol
         self._symbol = symbol
@@ -142,6 +157,8 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
             "Created entity for target_currency=%s",
             self._target_currency,
         )
+
+        self._update_properties()
 
     @staticmethod
     def safe_convert(value: float | None, conversion: float | None) -> float | None:
@@ -194,6 +211,23 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
         """Return the icon to use in the frontend, if any."""
         return self._icon
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        value = (
+            self._market_price is not None
+            and super().available
+            and not self._waiting_on_conversion
+        )
+        _LOGGER.info("%s available=%s", self._symbol, value)
+        return value
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_properties()
+        super()._handle_coordinator_update()
+
     def _round(self, value: float | None) -> float | int | None:
         """Return formatted value based on decimal_places."""
         if value is None:
@@ -206,9 +240,25 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
 
         return round(value, self._decimal_places)
 
+    def _find_symbol_data(self, symbol: str) -> any | None:
+        """Find data for the specified symbol in all coordinators."""
+        coordinators: dict[timedelta, YahooSymbolUpdateCoordinator] = self._hass.data[
+            DOMAIN
+        ][HASS_DATA_COORDINATORS]
+
+        if coordinators:
+            for coordinator in coordinators.values():
+                data = coordinator.data
+                if data is not None:
+                    symbol_data = data.get(symbol)
+                    if symbol_data is not None:
+                        return symbol_data
+
+        return None
+
     def _get_target_currency_conversion(self) -> float | None:
         value = None
-        self._waiting_on_converstion = False
+        self._waiting_on_conversion = False
 
         if self._target_currency and self._original_currency:
             if self._target_currency == self._original_currency:
@@ -218,22 +268,23 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
             conversion_symbol = (
                 f"{self._original_currency}{self._target_currency}=X".upper()
             )
-            data = self.coordinator.data
 
-            if data is not None:
-                symbol_data = data.get(conversion_symbol)
+            # Locate conversion symbol in all coordinators
+            symbol_data = self._find_symbol_data(conversion_symbol)
 
-                if symbol_data is not None:
-                    value = symbol_data[DATA_REGULAR_MARKET_PRICE]
-                    _LOGGER.debug("%s %s is %s", self._symbol, conversion_symbol, value)
-                else:
-                    _LOGGER.info(
-                        "%s No data found for %s, symbol added to coordinator",
-                        self._symbol,
-                        conversion_symbol,
-                    )
-                    self._waiting_on_converstion = True
-                    self.coordinator.add_symbol(conversion_symbol)
+            if symbol_data is not None:
+                value = symbol_data[DATA_REGULAR_MARKET_PRICE]
+                _LOGGER.debug("%s %s is %s", self._symbol, conversion_symbol, value)
+            else:
+                _LOGGER.info(
+                    "%s No data found for %s, symbol added to coordinator",
+                    self._symbol,
+                    conversion_symbol,
+                )
+                self._waiting_on_conversion = True
+
+                # The conversion symbol is added to the current coordinator
+                self.coordinator.add_symbol(conversion_symbol)
 
         return value
 
@@ -361,24 +412,3 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
             return "down"
 
         return "neutral"
-
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-
-        current_timer = timer()
-
-        # Limit data update if available was invoked within 400 ms.
-        # This matched the slow entity reporting done in Entity.
-        if (self._last_available_timer is None) or (
-            (current_timer - self._last_available_timer) > 0.4
-        ):
-            self._update_properties()
-            self._last_available_timer = current_timer
-
-        return_value = (
-            self.coordinator.last_update_success and not self._waiting_on_converstion
-        )
-
-        _LOGGER.info("%s available=%s", self._symbol, return_value)
-        return return_value


### PR DESCRIPTION
This request addresses #80.

* Symbol can now have scan_interval override defined
* If symbol needs converter symbol, then it will be refreshed on the same interval unless it has already been registered.
* Sensor update now happens through `_handle_coordinator_update` override instead of `available` which is more streamlined.
* A symbol is considered not available if it has no market value.