### PR TITLE
Converted market times sensor to ISO Date Time format & added AUD Currency

### DIFF
--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -13,6 +13,8 @@ ATTR_SYMBOL: Final = "symbol"
 ATTR_TRENDING: Final = "trending"
 ATTR_MARKET_STATE: Final = "marketState"
 ATTR_DIVIDEND_DATE: Final = "dividendDate"
+ATTR_REGULAR_MARKET_TIME: Final = "regularMarketTime"
+ATTR_POST_MARKET_TIME: Final = "postMarketTime"
 
 # Hass data
 HASS_DATA_CONFIG: Final = "config"
@@ -26,6 +28,9 @@ DATA_QUOTE_SOURCE_NAME: Final = "quoteSourceName"
 DATA_SHORT_NAME: Final = "shortName"
 DATA_MARKET_STATE: Final = "marketState"
 DATA_DIVIDEND_DATE: Final = "dividendDate"
+DATA_REGULAR_MARKET_TIME: Final = "regularMarketTime"
+DATA_POST_MARKET_TIME: Final = "postMarketTime"
+
 
 DATA_REGULAR_MARKET_PREVIOUS_CLOSE: Final = "regularMarketPreviousClose"
 DATA_REGULAR_MARKET_PRICE: Final = "regularMarketPrice"
@@ -66,7 +71,7 @@ NUMERIC_DATA_GROUPS: Final = {
         (DATA_REGULAR_MARKET_PREVIOUS_CLOSE, True),
         (DATA_REGULAR_MARKET_PRICE, True),
         ("regularMarketVolume", False),
-        ("regularMarketTime", False),
+        (DATA_REGULAR_MARKET_TIME, False),
         (DATA_DIVIDEND_DATE, False),
     ],
     CONF_INCLUDE_FIFTY_DAY_VALUES: [
@@ -84,7 +89,7 @@ NUMERIC_DATA_GROUPS: Final = {
         ("postMarketChange", True),
         ("postMarketChangePercent", False),
         ("postMarketPrice", True),
-        ("postMarketTime", False),
+        (DATA_POST_MARKET_TIME, False),
     ],
     CONF_INCLUDE_TWO_HUNDRED_DAY_VALUES: [
         ("twoHundredDayAverage", True),
@@ -160,6 +165,7 @@ CRUMB_RETRY_DELAY_429: Final = 60
 """Duration for crumb re-try when receiving 429 code."""
 
 CURRENCY_CODES: Final = {
+    "aud": "$",
     "bdt": "৳",
     "brl": "R$",
     "btc": "₿",

--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -14,6 +14,7 @@ ATTR_TRENDING: Final = "trending"
 ATTR_MARKET_STATE: Final = "marketState"
 ATTR_DIVIDEND_DATE: Final = "dividendDate"
 ATTR_REGULAR_MARKET_TIME: Final = "regularMarketTime"
+ATTR_PRE_MARKET_TIME: Final = "preMarketTime"
 ATTR_POST_MARKET_TIME: Final = "postMarketTime"
 
 # Hass data
@@ -29,7 +30,9 @@ DATA_SHORT_NAME: Final = "shortName"
 DATA_MARKET_STATE: Final = "marketState"
 DATA_DIVIDEND_DATE: Final = "dividendDate"
 DATA_REGULAR_MARKET_TIME: Final = "regularMarketTime"
+DATA_PRE_MARKET_TIME: Final = 'preMarketTime'
 DATA_POST_MARKET_TIME: Final = "postMarketTime"
+
 
 
 DATA_REGULAR_MARKET_PREVIOUS_CLOSE: Final = "regularMarketPreviousClose"
@@ -82,7 +85,7 @@ NUMERIC_DATA_GROUPS: Final = {
     CONF_INCLUDE_PRE_VALUES: [
         ("preMarketChange", True),
         ("preMarketChangePercent", False),
-        ("preMarketTime", False),
+        (DATA_PRE_MARKET_TIME, False),
         ("preMarketPrice", True),
     ],
     CONF_INCLUDE_POST_VALUES: [

--- a/custom_components/yahoofinance/sensor.py
+++ b/custom_components/yahoofinance/sensor.py
@@ -179,7 +179,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
 
         date_timestamp = convert_to_float(date_timestamp)
         if date_timestamp is None or date_timestamp == 0:
-            return 0
+            return date_timestamp
 
         converted_date = datetime.fromtimestamp(date_timestamp,tz=dt_util.DEFAULT_TIME_ZONE)
         if return_format == "date":

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -23,6 +23,9 @@ from custom_components.yahoofinance.const import (
     DATA_DIVIDEND_DATE,
     DATA_REGULAR_MARKET_PREVIOUS_CLOSE,
     DATA_REGULAR_MARKET_PRICE,
+    DATA_PRE_MARKET_TIME,
+    DATA_POST_MARKET_TIME,
+    DATA_REGULAR_MARKET_TIME,
     DATA_SHORT_NAME,
     DEFAULT_CONF_DECIMAL_PLACES,
     DEFAULT_CONF_INCLUDE_FIFTY_DAY_VALUES,
@@ -165,9 +168,9 @@ def test_sensor_creation(
     for data_group in NUMERIC_DATA_GROUPS.values():
         for value in data_group:
             key = value[0]
-            if (key != DATA_REGULAR_MARKET_PRICE) and (key != DATA_DIVIDEND_DATE):   # noqa: PLR1714
+            if (key != DATA_REGULAR_MARKET_PRICE) and (key != DATA_DIVIDEND_DATE) and (key != DATA_REGULAR_MARKET_TIME) and (key != DATA_PRE_MARKET_TIME) and (key != DATA_POST_MARKET_TIME):   # noqa: PLR1714
                 assert attributes[key] == 0
-
+   
     # Since we did not provide any data so currency should be the default value
     assert sensor.unit_of_measurement == DEFAULT_CURRENCY
     assert attributes[ATTR_CURRENCY_SYMBOL] == DEFAULT_CURRENCY_SYMBOL

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -458,15 +458,21 @@ def test_conversion_not_attempted_if_target_currency_same(hass):
 
 
 @pytest.mark.parametrize(
-    "dividend_date,expected_date",
+    "epoch_date,return_format,expected_datetime",
     [
-        (None, None),
-        (1642118400, "2022-01-14"),
-        (1646870400, "2022-03-10"),
-        ("1646870400", "2022-03-10"),
-        ("164687040 0", None),
+        (None, "date", None),
+        (1642118400, "date","2022-01-14"),
+        (1646870400, "date","2022-03-10"),
+        ("1646870400", "date","2022-03-10"),
+        ("164687040 0", "date",None),
+        (1642118453, "datetime","2022-01-14T00:00:53+00:00"),
+        (1646878750, "datetime","2022-03-10T02:19:10+00:00"),
+        ("1646878750", "datetime","2022-03-10T02:19:10+00:00"),
+        ("164687040 0", "datetime",None),
+        (0, "date",0),
+        (0, "datetime",0),
     ],
 )
-def test_parse_dividend_date(dividend_date, expected_date):
-    """Test dividend date parsing."""
-    assert YahooFinanceSensor.parse_dividend_date(dividend_date) == expected_date
+def test_convert_timestamp_to_datetime(epoch_date,return_format,expected_datetime):
+    """Test converting Epoch times to datetime and return date or datetime based on return format."""
+    assert YahooFinanceSensor.convert_timestamp_to_datetime(epoch_date,return_format) == expected_datetime


### PR DESCRIPTION
This update provides 2 enhancements to your code
1. Added AUD currency code so currency attribute will now correctly identify and display Australian stocks currencies. Previously it was displaying unknown.
2. The regularMarketTime & postMarketTime attributes were being displayed in Epoch, added code to convert these to a full DateTime with TimeZone aware value.