### PR TITLE
Throttle crumb retry

### DIFF
--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import logging
 from typing import Final
 
 # Additional attributes exposed by the sensor
@@ -210,3 +211,5 @@ CURRENCY_CODES: Final = {
     "xpf": "CFPF",
     "xxx": "¤",
 }
+
+LOGGER = logging.getLogger(__name__)

--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -173,6 +173,9 @@ CRUMB_RETRY_DELAY: Final = 15
 CRUMB_RETRY_DELAY_429: Final = 60
 """Duration for crumb re-try when receiving 429 code."""
 
+TOO_MANY_CRUMB_RETRY_FAILURES_DELAY: Final = 300
+TOO_MANY_CRUMB_RETRY_FAILURES_COUNT: Final = 5
+
 CURRENCY_CODES: Final = {
     "aud": "$",
     "bdt": "৳",

--- a/custom_components/yahoofinance/coordinator.py
+++ b/custom_components/yahoofinance/coordinator.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from datetime import timedelta
 from http import HTTPStatus
 from http.cookies import SimpleCookie
-import logging
 import re
 from typing import Any, Final
 
@@ -30,6 +29,7 @@ from .const import (
     GET_CRUMB_URL,
     INITIAL_REQUEST_HEADERS,
     INITIAL_URL,
+    LOGGER,
     MANUAL_SCAN_INTERVAL,
     NUMERIC_DATA_DEFAULTS,
     NUMERIC_DATA_GROUPS,
@@ -39,7 +39,6 @@ from .const import (
     TOO_MANY_CRUMB_RETRY_FAILURES_DELAY,
 )
 
-_LOGGER = logging.getLogger(__name__)
 REQUEST_TIMEOUT: Final = 10
 DELAY_ASYNC_REQUEST_REFRESH: Final = 5
 FAILURE_ASYNC_REQUEST_REFRESH: Final = 20
@@ -90,17 +89,15 @@ class CrumbCoordinator:
             data = await self.initial_navigation(consent_data.successful_consent_url)
 
             if data is None:  # Something went bad, we did get consent
-                _LOGGER.error("Post consent navigation failed")
+                LOGGER.error("Post consent navigation failed")
                 return None
 
             if data.need_consent:
-                _LOGGER.error(
-                    "Yahoo reported needing consent even after we got it once"
-                )
+                LOGGER.error("Yahoo reported needing consent even after we got it once")
                 return None
 
         if self.cookies_missing():
-            _LOGGER.error("Attempting to get crumb but have no cookies")
+            LOGGER.error("Attempting to get crumb but have no cookies")
 
         await self.try_crumb_page()
         return self.crumb
@@ -114,7 +111,7 @@ class CrumbCoordinator:
         """
 
         websession = async_get_clientsession(self._hass)
-        _LOGGER.debug("Navigating to base page %s", url)
+        LOGGER.debug("Navigating to base page %s", url)
 
         try:
             async with websession.get(
@@ -122,10 +119,10 @@ class CrumbCoordinator:
                 headers=INITIAL_REQUEST_HEADERS,
                 timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT),
             ) as response:
-                _LOGGER.debug("Response %d, URL: %s", response.status, response.url)
+                LOGGER.debug("Response %d, URL: %s", response.status, response.url)
 
                 if response.status != HTTPStatus.OK:
-                    _LOGGER.error(
+                    LOGGER.error(
                         "Failed to navigate to %s, status=%d, reason=%s",
                         url,
                         response.status,
@@ -139,7 +136,7 @@ class CrumbCoordinator:
 
                 # https://guce.yahoo.com/consent?brandType=nonEu&gcrumb=eZ_Jbm0&done=https%3A%2F%2Ffinance.yahoo.com%2F
                 if response.url.host.lower() == CONSENT_HOST:
-                    _LOGGER.info("Consent page %s detected", response.url)
+                    LOGGER.info("Consent page %s detected", response.url)
 
                     return ConsentData(
                         need_consent=True,
@@ -147,12 +144,12 @@ class CrumbCoordinator:
                         consent_post_url=response.url,
                     )
 
-                _LOGGER.debug("No consent needed, have cookies=%s", bool(self.cookies))
+                LOGGER.debug("No consent needed, have cookies=%s", bool(self.cookies))
 
         except TimeoutError as ex:
-            _LOGGER.error("Timed out accessing initial url. %s", ex)
+            LOGGER.error("Timed out accessing initial url. %s", ex)
         except aiohttp.ClientError as ex:
-            _LOGGER.error("Error accessing initial url. %s", ex)
+            LOGGER.error("Error accessing initial url. %s", ex)
 
         return ConsentData()
 
@@ -161,7 +158,7 @@ class CrumbCoordinator:
 
         websession = async_get_clientsession(self._hass)
         form_data = self.build_consent_form_data(consent_data.consent_content)
-        _LOGGER.debug("Posting consent %s", str(form_data))
+        LOGGER.debug("Posting consent %s", str(form_data))
 
         try:
             async with asyncio.timeout(REQUEST_TIMEOUT):
@@ -177,7 +174,7 @@ class CrumbCoordinator:
                 # 200
 
                 if response.status != HTTPStatus.OK:
-                    _LOGGER.error(
+                    LOGGER.error(
                         "Failed to post consent %d, reason=%s",
                         response.status,
                         response.reason,
@@ -189,15 +186,15 @@ class CrumbCoordinator:
 
                 consent_data.successful_consent_url = response.url
 
-                _LOGGER.debug(
+                LOGGER.debug(
                     "After consent processing, have cookies=%s", bool(self.cookies)
                 )
                 return True
 
         except TimeoutError as ex:
-            _LOGGER.error("Timed out processing consent. %s", ex)
+            LOGGER.error("Timed out processing consent. %s", ex)
         except aiohttp.ClientError as ex:
-            _LOGGER.error("Error accessing consent url. %s", ex)
+            LOGGER.error("Error accessing consent url. %s", ex)
 
         return False
 
@@ -208,7 +205,7 @@ class CrumbCoordinator:
     async def try_crumb_page(self) -> str | None:
         """Try to get crumb from the end point."""
 
-        _LOGGER.info("Accessing crumb page")
+        LOGGER.info("Accessing crumb page")
         websession = async_get_clientsession(self._hass)
 
         async with websession.get(
@@ -217,18 +214,18 @@ class CrumbCoordinator:
             timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT),
             cookies=self.cookies,
         ) as response:
-            _LOGGER.debug("Crumb response status: %d, %s", response.status, response)
+            LOGGER.debug("Crumb response status: %d, %s", response.status, response)
 
             if response.status == HTTPStatus.OK:
                 self.crumb = await response.text()
                 if not self.crumb:
-                    _LOGGER.error("No crumb reported")
+                    LOGGER.error("No crumb reported")
 
-                _LOGGER.debug("Crumb page reported %s", self.crumb)
+                LOGGER.debug("Crumb page reported %s", self.crumb)
                 self._crumb_retry_count = 0
                 return self.crumb
 
-            _LOGGER.error(
+            LOGGER.error(
                 "Crumb request responded with status=%d, reason=%s",
                 response.status,
                 response.reason,
@@ -251,16 +248,16 @@ class CrumbCoordinator:
     # async def parse_crumb_from_content(self, content: str) -> str:
     #     """Parse and update crumb from response content."""
 
-    #     _LOGGER.debug("Parsing crumb from content (length: %d)", len(content))
+    #     LOGGER.debug("Parsing crumb from content (length: %d)", len(content))
 
     #     start_pos = content.find('"crumb":"')
-    #     _LOGGER.debug("Start position: %d", start_pos)
+    #     LOGGER.debug("Start position: %d", start_pos)
     #     end_pos = -1
 
     #     if start_pos != -1:
     #         start_pos = start_pos + 9
     #         end_pos = content.find('"', start_pos + 10)
-    #         _LOGGER.debug("End position: %d", end_pos)
+    #         LOGGER.debug("End position: %d", end_pos)
     #         if end_pos != -1:
     #             self.crumb = (
     #                 content[start_pos:end_pos]
@@ -270,13 +267,13 @@ class CrumbCoordinator:
 
     #     # Crumb was not located
     #     if not self.crumb:
-    #         _LOGGER.info(
+    #         LOGGER.info(
     #             "Crumb not found, start position: %d, ending position: %d. Refer to YahooFinanceCrumbContent.log in the config folder.",
     #             start_pos,
     #             end_pos,
     #         )
 
-    #         if _LOGGER.isEnabledFor(logging.INFO):
+    #         if LOGGER.isEnabledFor(logging.INFO):
     #             await self._hass.async_add_executor_job(
     #                 write_utf8_file,
     #                 self._hass.config.path("YahooFinanceCrumbContent.log"),
@@ -336,7 +333,7 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         conversion_symbol = f"{from_currency}{to_currency}=X"
 
         if conversion_symbol != symbol:
-            _LOGGER.info(
+            LOGGER.info(
                 "Conversion symbol updated to %s from %s", conversion_symbol, symbol
             )
 
@@ -364,7 +361,7 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         super().__init__(
             hass,
-            _LOGGER,
+            LOGGER,
             name="YahooSymbolUpdateCoordinator",
             update_interval=update_interval,
         )
@@ -392,7 +389,7 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._async_request_refresh_later,
             )
 
-            _LOGGER.info(
+            LOGGER.info(
                 "Added %s and requested update in %d seconds",
                 symbol,
                 DELAY_ASYNC_REQUEST_REFRESH,
@@ -406,7 +403,7 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         url = await self.build_request_url()
         cookies = self._cc.cookies
-        _LOGGER.debug("Requesting data from '%s'", url)
+        LOGGER.debug("Requesting data from '%s'", url)
 
         async with asyncio.timeout(REQUEST_TIMEOUT):
             response = await self.websession.get(
@@ -431,7 +428,7 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     finance_error_description,
                 ) = finance_error_code_tuple
 
-                _LOGGER.error(
+                LOGGER.error(
                     "Received status %d (%s %s) for %s",
                     response.status,
                     finance_error_code,
@@ -441,11 +438,11 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
                 # Reset crumb so that it gets recalculated
                 if finance_error_code == "Unauthorized":
-                    _LOGGER.log("Resetting crumbs")
+                    LOGGER.log("Resetting crumbs")
                     self._cc.reset()
 
             else:
-                _LOGGER.error(
+                LOGGER.error(
                     "Received status %d for %s, result=%s",
                     response.status,
                     url,
@@ -518,9 +515,9 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.update_interval = self._defined_update_interval
 
         if error_encountered:
-            _LOGGER.info("Data = %s", result)
+            LOGGER.info("Data = %s", result)
         else:
-            _LOGGER.debug("Data = %s", result)
+            LOGGER.debug("Data = %s", result)
 
         return data
 
@@ -549,19 +546,19 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     symbols.remove(fixed_symbol)
                     symbol = fixed_symbol
                 else:
-                    _LOGGER.warning("Received %s not in symbol list", symbol)
+                    LOGGER.warning("Received %s not in symbol list", symbol)
                     error_encountered = True
 
             data[symbol] = self.parse_symbol_data(symbol_data)
 
-            _LOGGER.debug(
+            LOGGER.debug(
                 "Updated %s to %s",
                 symbol,
                 data[symbol][DATA_REGULAR_MARKET_PRICE],
             )
 
         if len(symbols) > 0:
-            _LOGGER.warning("No data received for %s", symbols)
+            LOGGER.warning("No data received for %s", symbols)
             error_encountered = True
 
         return (error_encountered, data)

--- a/custom_components/yahoofinance/sensor.py
+++ b/custom_components/yahoofinance/sensor.py
@@ -6,7 +6,6 @@ https://github.com/iprak/yahoofinance
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-import logging
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -56,12 +55,12 @@ from .const import (
     DOMAIN,
     HASS_DATA_CONFIG,
     HASS_DATA_COORDINATORS,
+    LOGGER,
     NUMERIC_DATA_GROUPS,
     PERCENTAGE_DATA_KEYS_NEEDING_MULTIPLICATION,
 )
 from .coordinator import YahooSymbolUpdateCoordinator
 
-_LOGGER = logging.getLogger(__name__)
 ENTITY_ID_FORMAT = SENSOR_DOMAIN + "." + DOMAIN + "_{}"
 
 
@@ -90,7 +89,7 @@ async def async_setup_platform(
 
     # We have already invoked async_refresh on coordinator, so don'tupdate_before_add
     async_add_entities(sensors, update_before_add=False)
-    _LOGGER.info("Entities added for %s", [item.symbol for item in symbol_definitions])
+    LOGGER.info("Entities added for %s", [item.symbol for item in symbol_definitions])
 
 
 class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
@@ -161,7 +160,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
                     self._attr_extra_state_attributes[key] = None
 
         # Delay initial data population to `available` which is called from `_async_write_ha_state`
-        _LOGGER.debug(
+        LOGGER.debug(
             "Created entity for target_currency=%s",
             self._target_currency,
         )
@@ -237,7 +236,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
             and super().available
             and not self._waiting_on_conversion
         )
-        _LOGGER.debug("%s available=%s", self._symbol, value)
+        LOGGER.debug("%s available=%s", self._symbol, value)
         return value
 
     @callback
@@ -280,7 +279,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
 
         if self._target_currency and self._original_currency:
             if self._target_currency == self._original_currency:
-                _LOGGER.info("%s No conversion necessary", self._symbol)
+                LOGGER.info("%s No conversion necessary", self._symbol)
                 return None
 
             conversion_symbol = (
@@ -292,9 +291,9 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
 
             if symbol_data is not None:
                 value = symbol_data[DATA_REGULAR_MARKET_PRICE]
-                _LOGGER.debug("%s %s is %s", self._symbol, conversion_symbol, value)
+                LOGGER.debug("%s %s is %s", self._symbol, conversion_symbol, value)
             else:
-                _LOGGER.info(
+                LOGGER.info(
                     "%s No data found for %s, symbol added to coordinator",
                     self._symbol,
                     conversion_symbol,
@@ -318,7 +317,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
         financial_currency = symbol_data[DATA_FINANCIAL_CURRENCY]
         currency = symbol_data[DATA_CURRENCY_SYMBOL]
 
-        _LOGGER.debug(
+        LOGGER.debug(
             "%s currency=%s financialCurrency=%s",
             self._symbol,
             currency,
@@ -332,12 +331,12 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
 
         data = self.coordinator.data
         if data is None:
-            _LOGGER.debug("%s Coordinator data is None", self._symbol)
+            LOGGER.debug("%s Coordinator data is None", self._symbol)
             return
 
         symbol_data: dict = data.get(self._symbol)
         if symbol_data is None:
-            _LOGGER.debug("%s Symbol data is None", self._symbol)
+            LOGGER.debug("%s Symbol data is None", self._symbol)
             return
 
         self._update_original_currency(symbol_data)
@@ -350,7 +349,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
         # _market_price gets rounded in the `state` getter.
 
         if conversion:
-            _LOGGER.info(
+            LOGGER.info(
                 "%s converted %s X %s = %s",
                 self._symbol,
                 market_price,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -19,6 +19,7 @@ from custom_components.yahoofinance.coordinator import (
     FAILURE_ASYNC_REQUEST_REFRESH,
     CrumbCoordinator,
 )
+from homeassistant.core import HomeAssistant
 
 from . import TEST_CRUMB, TEST_SYMBOL
 from .conftest import create_mock_coordinator
@@ -39,7 +40,7 @@ YSUC = "custom_components.yahoofinance.YahooSymbolUpdateCoordinator"
     ],
 )
 async def test_incomplete_json(
-    hass, parsed_json, message, mocked_crumb_coordinator
+    hass: HomeAssistant, parsed_json, message, mocked_crumb_coordinator
 ) -> None:
     """Existing data is not updated if JSON is invalid."""
 
@@ -71,7 +72,7 @@ async def test_incomplete_json(
     ],
 )
 async def test_json_download_failure(
-    hass, raised_exception, mocked_crumb_coordinator
+    hass: HomeAssistant, raised_exception, mocked_crumb_coordinator
 ) -> None:
     """Existing data is not updated if exception encountered while downloading json."""
 
@@ -98,7 +99,7 @@ async def test_json_download_failure(
 
 
 async def test_successful_data_parsing(
-    hass, mocked_crumb_coordinator, mock_json
+    hass: HomeAssistant, mocked_crumb_coordinator, mock_json
 ) -> None:
     """Tests successful data parsing."""
 
@@ -113,7 +114,7 @@ async def test_successful_data_parsing(
     assert mock_coordinator.last_update_success is True
 
 
-async def test_add_symbol(hass, mocked_crumb_coordinator) -> None:
+async def test_add_symbol(hass: HomeAssistant, mocked_crumb_coordinator) -> None:
     """Add symbol for load."""
     mock_coordinator = YahooSymbolUpdateCoordinator(
         [], hass, DEFAULT_SCAN_INTERVAL, mocked_crumb_coordinator
@@ -125,7 +126,9 @@ async def test_add_symbol(hass, mocked_crumb_coordinator) -> None:
         assert len(mock_call_later.mock_calls) == 1
 
 
-async def test_add_symbol_existing(hass, mocked_crumb_coordinator) -> None:
+async def test_add_symbol_existing(
+    hass: HomeAssistant, mocked_crumb_coordinator
+) -> None:
     """Test check for existing symbols."""
     mock_coordinator = YahooSymbolUpdateCoordinator(
         [TEST_SYMBOL], hass, DEFAULT_SCAN_INTERVAL, mocked_crumb_coordinator
@@ -134,7 +137,7 @@ async def test_add_symbol_existing(hass, mocked_crumb_coordinator) -> None:
 
 
 async def test_update_interval_when_update_fails(
-    hass, mocked_crumb_coordinator
+    hass: HomeAssistant, mocked_crumb_coordinator
 ) -> None:
     """Update interval for the next async_track_point_in_utc_time call."""
     mock_coordinator = YahooSymbolUpdateCoordinator(
@@ -151,7 +154,9 @@ async def test_update_interval_when_update_fails(
     )
 
 
-async def test_update_when_update_is_disabled(hass, mocked_crumb_coordinator) -> None:
+async def test_update_when_update_is_disabled(
+    hass: HomeAssistant, mocked_crumb_coordinator
+) -> None:
     """No update is performed if update_interval is None."""
 
     mock_coordinator = YahooSymbolUpdateCoordinator(
@@ -186,7 +191,7 @@ async def test_update_when_update_is_disabled(hass, mocked_crumb_coordinator) ->
     ],
 )
 async def test_fix_conversion_symbol(
-    hass, symbol, symbol_data, expected_symbol, mocked_crumb_coordinator
+    hass: HomeAssistant, symbol, symbol_data, expected_symbol, mocked_crumb_coordinator
 ) -> None:
     """Test conversion symbol correction."""
     mock_coordinator = YahooSymbolUpdateCoordinator(
@@ -235,7 +240,7 @@ async def test_fix_conversion_symbol(
     ],
 )
 async def test_process_json_result(
-    hass,
+    hass: HomeAssistant,
     symbols,
     result,
     expected_error_encountered,
@@ -261,7 +266,7 @@ async def test_process_json_result(
 
 
 async def test_logging_when_process_json_result_reports_error(
-    hass, mock_json, mocked_crumb_coordinator
+    hass: HomeAssistant, mock_json, mocked_crumb_coordinator
 ) -> None:
     """Tests call to logger.info() when process_json_result reports an error."""
     mock_coordinator = YahooSymbolUpdateCoordinator(
@@ -282,14 +287,14 @@ async def test_logging_when_process_json_result_reports_error(
         assert mock_logger.error.call_count == 1
 
 
-def test_crumbcoordinator_ctor(hass) -> None:
+def test_crumbcoordinator_ctor(hass: HomeAssistant) -> None:
     """Test CrumbCoordinator contructor."""
     instance = CrumbCoordinator(hass)
     assert instance.cookies is None
     assert instance.crumb is None
 
 
-def test_crumbcoordinator_reset(hass) -> None:
+def test_crumbcoordinator_reset(hass: HomeAssistant) -> None:
     """Test CrumbCoordinator contructor."""
     instance = CrumbCoordinator(hass)
     instance.cookies = "cookies"
@@ -300,7 +305,7 @@ def test_crumbcoordinator_reset(hass) -> None:
     assert instance.crumb is None
 
 
-async def test_build_request_url(hass, mocked_crumb_coordinator) -> None:
+async def test_build_request_url(hass: HomeAssistant, mocked_crumb_coordinator) -> None:
     """Test build_request_url."""
 
     mock_coordinator = YahooSymbolUpdateCoordinator(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -210,8 +210,9 @@ async def test_scan_interval(
     type(mock_instance).data = PropertyMock(return_value=None)
     type(mock_instance).last_update_success = PropertyMock(return_value=False)
 
-    with patch(YSUC, return_value=mock_instance), patch(
-        f"{YCC}.try_get_crumb_cookies", AsyncMock(return_value=TEST_CRUMB)
+    with (
+        patch(YSUC, return_value=mock_instance),
+        patch(f"{YCC}.try_get_crumb_cookies", AsyncMock(return_value=TEST_CRUMB)),
     ):
         config = {DOMAIN: domain_config}
 
@@ -237,8 +238,9 @@ async def test_setup_optionally_requests_coordinator_refresh(
     type(mock_instance).data = PropertyMock(return_value=None)
     type(mock_instance).last_update_success = PropertyMock(return_value=False)
 
-    with patch(YSUC, return_value=mock_instance), patch(
-        f"{YCC}.try_get_crumb_cookies", AsyncMock(return_value=TEST_CRUMB)
+    with (
+        patch(YSUC, return_value=mock_instance),
+        patch(f"{YCC}.try_get_crumb_cookies", AsyncMock(return_value=TEST_CRUMB)),
     ):
         assert await async_setup_component(hass, DOMAIN, SAMPLE_CONFIG) is True
         await hass.async_block_till_done()
@@ -253,11 +255,12 @@ async def test_refresh_symbols_service(
 ) -> None:
     """Test refresh_symbols service callback."""
 
-    with patch(
-        f"{YCC}.try_get_crumb_cookies", AsyncMock(return_value=TEST_CRUMB)
-    ), patch(
-        f"{YSUC}._async_update", AsyncMock(return_value=None)
-    ) as mock_async_request_refresh:
+    with (
+        patch(f"{YCC}.try_get_crumb_cookies", AsyncMock(return_value=TEST_CRUMB)),
+        patch(
+            f"{YSUC}._async_update_data", AsyncMock(return_value=None)
+        ) as mock_async_request_refresh,
+    ):
         assert await async_setup_component(hass, DOMAIN, SAMPLE_CONFIG) is True
         await hass.async_block_till_done()
         assert mock_async_request_refresh.call_count == 1


### PR DESCRIPTION
This limits crumb retrieval to five attempts, each after a sixty-second delay. After five failures, the retrieval process restarts after five minutes. This might give time to alleviate the 429 return code.