### PR TITLE
fix: try alternate user agents

### DIFF
--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -140,7 +140,7 @@ STRING_DATA_KEYS: Final = [
 ATTRIBUTION: Final = "Data provided by Yahoo Finance"
 BASE: Final = "https://query1.finance.yahoo.com/v7/finance/quote?symbols="
 
-INITIAL_URL: Final = "https://finance.yahoo.com/quote/NQ%3DF"
+INITIAL_URL: Final = "https://finance.yahoo.com/quote/NQ%3DF/"
 CONSENT_HOST: Final = "consent.yahoo.com"
 GET_CRUMB_URL: Final = "https://query2.finance.yahoo.com/v1/test/getcrumb"
 

--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -148,15 +148,19 @@ INITIAL_REQUEST_HEADERS: Final = {
     "accept": "text/html,application/xhtml+xml,application/xml",
     "accept-language": "en-US,en;q=0.9",
 }
-""" Headers for INITIAL_URL. The limited headers are at attempt to avoid `Got more than 8190 byte` error. """
+""" Headers for INITIAL_URL. The limited headers are an attempt to avoid `Got more than 8190 byte` error. """
 
-REQUEST_HEADERS: Final = {
+USER_AGENTS_FOR_XHR: Final = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+    "Mozilla/5.0",
+]
+
+XHR_REQUEST_HEADERS: Final = {
     "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
     "accept-encoding": "gzip,deflate,br,zstd",
     "accept-language": "en-US,en;q=0.9",
-    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
 }
-""" Headers for all other requests. """
+""" Headers for all XHR requests. """
 
 CONF_SYMBOLS: Final = "symbols"
 DEFAULT_CURRENCY: Final = "USD"

--- a/custom_components/yahoofinance/coordinator.py
+++ b/custom_components/yahoofinance/coordinator.py
@@ -229,7 +229,7 @@ class CrumbCoordinator:
                     if not self.crumb:
                         LOGGER.error("No crumb reported")
 
-                    LOGGER.debug("Crumb page reported %s", self.crumb)
+                    LOGGER.info("Crumb page reported %s", self.crumb)
                     self._crumb_retry_count = 0
                     return self.crumb
 
@@ -450,9 +450,14 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
 
         for user_agent in USER_AGENTS_FOR_XHR:
+            # Skip if we have already tried the agent
+            if preferred_user_agent == user_agent:
+                continue
+
             [result_json, status] = await self._fetch_json(url, user_agent)
 
             if status == HTTPStatus.OK:
+                LOGGER.info("Successful data received for '%s'", user_agent)
                 return result_json
 
             if status != 429:

--- a/custom_components/yahoofinance/coordinator.py
+++ b/custom_components/yahoofinance/coordinator.py
@@ -33,10 +33,11 @@ from .const import (
     MANUAL_SCAN_INTERVAL,
     NUMERIC_DATA_DEFAULTS,
     NUMERIC_DATA_GROUPS,
-    REQUEST_HEADERS,
     STRING_DATA_KEYS,
     TOO_MANY_CRUMB_RETRY_FAILURES_COUNT,
     TOO_MANY_CRUMB_RETRY_FAILURES_DELAY,
+    USER_AGENTS_FOR_XHR,
+    XHR_REQUEST_HEADERS,
 )
 
 REQUEST_TIMEOUT: Final = 10
@@ -49,6 +50,9 @@ class CrumbCoordinator:
 
     _instance = None
     """Static instance of CrumbCoordinator."""
+
+    preferred_user_agent = ""
+    """The preferred (last successeful) user agent."""
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize."""
@@ -207,43 +211,67 @@ class CrumbCoordinator:
 
         LOGGER.info("Accessing crumb page")
         websession = async_get_clientsession(self._hass)
+        timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)
+        last_status = 0
 
-        async with websession.get(
-            GET_CRUMB_URL,
-            headers=REQUEST_HEADERS,
-            timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT),
-            cookies=self.cookies,
-        ) as response:
-            LOGGER.debug("Crumb response status: %d, %s", response.status, response)
+        for user_agent in USER_AGENTS_FOR_XHR:
+            headers = {**XHR_REQUEST_HEADERS, "user-agent": user_agent}
 
-            if response.status == HTTPStatus.OK:
-                self.crumb = await response.text()
-                if not self.crumb:
-                    LOGGER.error("No crumb reported")
+            async with websession.get(
+                GET_CRUMB_URL, headers=headers, timeout=timeout, cookies=self.cookies
+            ) as response:
+                last_status = response.status
 
-                LOGGER.debug("Crumb page reported %s", self.crumb)
-                self._crumb_retry_count = 0
-                return self.crumb
+                if last_status == HTTPStatus.OK:
+                    self.preferred_user_agent = user_agent
 
-            LOGGER.error(
-                "Crumb request responded with status=%d, reason=%s",
-                response.status,
-                response.reason,
+                    self.crumb = await response.text()
+                    if not self.crumb:
+                        LOGGER.error("No crumb reported")
+
+                    LOGGER.debug("Crumb page reported %s", self.crumb)
+                    self._crumb_retry_count = 0
+                    return self.crumb
+
+                # Try next user-agent for 429, stop trying for any other failures
+                if last_status == 429:
+                    LOGGER.info(
+                        "Crumb request responded with status 429 for '%s', re-trying with different agent",
+                        user_agent,
+                    )
+                else:
+                    LOGGER.error(
+                        "Crumb request responded with status=%d, reason=%s",
+                        last_status,
+                        response.reason,
+                    )
+
+                    break
+
+        self._crumb_retry_count = self._crumb_retry_count + 1
+
+        if self._crumb_retry_count > TOO_MANY_CRUMB_RETRY_FAILURES_COUNT:
+            self.retry_duration = TOO_MANY_CRUMB_RETRY_FAILURES_DELAY
+            LOGGER.info(
+                "Too many crumb failures, will retry after %d seconds",
+                self.retry_duration,
             )
 
-            self._crumb_retry_count = self._crumb_retry_count + 1
-
-            if self._crumb_retry_count > TOO_MANY_CRUMB_RETRY_FAILURES_COUNT:
-                self.retry_duration = TOO_MANY_CRUMB_RETRY_FAILURES_DELAY
-                self._crumb_retry_count = 0
-            elif response.status == 429:
+            self._crumb_retry_count = 0
+        else:
+            if last_status == 429:
                 # Ideally we would want to use the seconds passed back in the header
                 # for 429 but there seems to be no such value.
                 self.retry_duration = CRUMB_RETRY_DELAY_429
             else:
                 self.retry_duration = CRUMB_RETRY_DELAY
 
-            return None
+            LOGGER.info(
+                "Crumb failure, will retry after %d seconds",
+                self.retry_duration,
+            )
+
+        return None
 
     # async def parse_crumb_from_content(self, content: str) -> str:
     #     """Parse and update crumb from response content."""
@@ -402,18 +430,60 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Get the JSON data."""
 
         url = await self.build_request_url()
-        cookies = self._cc.cookies
-        LOGGER.debug("Requesting data from '%s'", url)
+
+        preferred_user_agent = self._cc.preferred_user_agent
+        if preferred_user_agent:
+            LOGGER.info(
+                "Requesting data request with the preferred agent '%s'",
+                preferred_user_agent,
+            )
+
+            [result_json, status] = await self._fetch_json(url, preferred_user_agent)
+
+            if status == HTTPStatus.OK:
+                return result_json
+
+            if status == 429:
+                LOGGER.info(
+                    "Data request responded with status 429 for '%s', re-trying other agents",
+                    preferred_user_agent,
+                )
+
+        for user_agent in USER_AGENTS_FOR_XHR:
+            [result_json, status] = await self._fetch_json(url, user_agent)
+
+            if status == HTTPStatus.OK:
+                return result_json
+
+            if status != 429:
+                break
+
+            LOGGER.info(
+                "Data request responded with status 429 for '%s', re-trying with different agent",
+                user_agent,
+            )
+
+        return None
+
+    async def _fetch_json(self, url, user_agent) -> tuple[dict, int]:
+        """Fetch JSON data with the specified user agent."""
+
+        headers = {**XHR_REQUEST_HEADERS, "user-agent": user_agent}
+        LOGGER.debug("Requesting data from '%s' with agent %s", url, user_agent)
 
         async with asyncio.timeout(REQUEST_TIMEOUT):
             response = await self.websession.get(
-                url, headers=REQUEST_HEADERS, cookies=cookies
+                url, headers=headers, cookies=self._cc.cookies
             )
+
+            # Try next user-agent for 429
+            if response.status == 429:
+                return [None, 429]
 
             result_json = await response.json()
 
             if response.status == HTTPStatus.OK:
-                return result_json
+                return [result_json, response.status]
 
             # Sample errors:
             #   {'finance':{'result': None, 'error': {'code': 'Unauthorized', 'description': 'Invalid Crumb'}}}
@@ -428,7 +498,7 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     finance_error_description,
                 ) = finance_error_code_tuple
 
-                LOGGER.error(
+                LOGGER.info(
                     "Received status %d (%s %s) for %s",
                     response.status,
                     finance_error_code,
@@ -442,14 +512,14 @@ class YahooSymbolUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     self._cc.reset()
 
             else:
-                LOGGER.error(
+                LOGGER.info(
                     "Received status %d for %s, result=%s",
                     response.status,
                     url,
                     result_json,
                 )
 
-        return None
+        return [None, response.status]
 
     async def build_request_url(self) -> str:
         """Build the request url."""
@@ -576,3 +646,8 @@ class ConsentData:
     """Url to navigate to after successful consent"""
     need_consent: bool = False
     """Consent is needed"""
+
+
+def debug_log_response(response: aiohttp.ClientResponse, title: str) -> None:
+    """Debug log the response."""
+    LOGGER.debug("%s: %d, %s", title, response.status, response.reason)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -289,7 +289,7 @@ async def test_logging_when_process_json_result_reports_error(
         await mock_coordinator.async_refresh()
         await hass.async_block_till_done()
 
-        assert mock_logger.error.call_count == 1
+        assert mock_logger.info.call_count == 1
 
 
 def test_crumbcoordinator_ctor(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Testing showed that well defined user-agent as sent by browser e.g. `"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0` is causing 529.

Now attempt is made to get data with an alternate simplified user-agent i.e. Mozilla/5.0.

This was confirmed to succeed in getting data from data centers on US-West, US-East and Germany.