### PR TITLE
fix: pass user-agent for consent navigation

### DIFF
--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -147,12 +147,13 @@ GET_CRUMB_URL: Final = "https://query2.finance.yahoo.com/v1/test/getcrumb"
 INITIAL_REQUEST_HEADERS: Final = {
     "accept": "text/html,application/xhtml+xml,application/xml",
     "accept-language": "en-US,en;q=0.9",
+    "user-agent": "Mozilla/5.0",
 }
 """ Headers for INITIAL_URL. The limited headers are an attempt to avoid `Got more than 8190 byte` error. """
 
 USER_AGENTS_FOR_XHR: Final = [
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
     "Mozilla/5.0",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
 ]
 
 XHR_REQUEST_HEADERS: Final = {

--- a/custom_components/yahoofinance/coordinator.py
+++ b/custom_components/yahoofinance/coordinator.py
@@ -101,7 +101,9 @@ class CrumbCoordinator:
                 return None
 
         if self.cookies_missing():
-            LOGGER.error("Attempting to get crumb but have no cookies")
+            LOGGER.warning(
+                "Attempting to get crumb but have no cookies, the operation might fail"
+            )
 
         await self.try_crumb_page()
         return self.crumb
@@ -312,7 +314,7 @@ class CrumbCoordinator:
         """Build consent form data from response content."""
         pattern = r'<input.*?type="hidden".*?name="(.*?)".*?value="(.*?)".*?>'
         matches = re.findall(pattern, content)
-        basic_data = {"reject": "reject"}
+        basic_data = {"reject": "reject"}  # From "Reject" submit button
         additional_data = dict(matches)
         return {**basic_data, **additional_data}
 


### PR DESCRIPTION
It seems that consent navigation has started failing due to lack of user-agent. Passing the agent results in "Got more than 8190 bytes" error but the next retry succeeds.