### PR TITLE
fix: use longName if shortName is the same as symbol

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -23,7 +23,7 @@ yahoofinance:
   scan_interval: 45
 
   symbols:
-    - symbol: "ISTNX"
+    - symbol: "0P00008F5Y.L"
     - symbol: GBPUSD=X
       no_unit: true
     - symbol: IDFCBANK.BO

--- a/custom_components/yahoofinance/const.py
+++ b/custom_components/yahoofinance/const.py
@@ -29,6 +29,7 @@ DATA_CURRENCY_SYMBOL: Final = "currency"
 DATA_FINANCIAL_CURRENCY: Final = "financialCurrency"
 DATA_QUOTE_TYPE: Final = "quoteType"
 DATA_QUOTE_SOURCE_NAME: Final = "quoteSourceName"
+DATA_LONG_NAME: Final = "longName"
 DATA_SHORT_NAME: Final = "shortName"
 DATA_MARKET_STATE: Final = "marketState"
 DATA_DIVIDEND_DATE: Final = "dividendDate"
@@ -132,6 +133,7 @@ STRING_DATA_KEYS: Final = [
     DATA_FINANCIAL_CURRENCY,
     DATA_QUOTE_TYPE,
     DATA_QUOTE_SOURCE_NAME,
+    DATA_LONG_NAME,
     DATA_SHORT_NAME,
     DATA_MARKET_STATE,
 ]

--- a/custom_components/yahoofinance/sensor.py
+++ b/custom_components/yahoofinance/sensor.py
@@ -41,6 +41,7 @@ from .const import (
     DATA_CURRENCY_SYMBOL,
     DATA_DIVIDEND_DATE,
     DATA_FINANCIAL_CURRENCY,
+    DATA_LONG_NAME,
     DATA_MARKET_STATE,
     DATA_POST_MARKET_TIME,
     DATA_PRE_MARKET_TIME,
@@ -100,6 +101,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
     _currency = DEFAULT_CURRENCY
     _icon = None
     _market_price = None
+    _long_name = None
     _short_name = None
     _target_currency = None
     _original_currency = None
@@ -202,7 +204,13 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
     def name(self) -> str:
         """Return the name of the sensor."""
         if self._short_name is not None:
-            return self._short_name
+            # In UK regions, shortName was reported to be the same as symbol.
+            # Falling to longName if that is available in that case.
+            if self._short_name == self._symbol:
+                if self._long_name is not None:
+                    return self._long_name
+            else:
+                return self._short_name
 
         return self._symbol
 
@@ -344,6 +352,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
         conversion = self._get_target_currency_conversion()
 
         self._short_name = symbol_data[DATA_SHORT_NAME]
+        self._long_name = symbol_data[DATA_LONG_NAME]
 
         market_price = symbol_data[DATA_REGULAR_MARKET_PRICE]
         self._market_price = self.safe_convert(market_price, conversion)

--- a/custom_components/yahoofinance/sensor.py
+++ b/custom_components/yahoofinance/sensor.py
@@ -102,7 +102,8 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
     _icon = None
     _market_price = None
     _long_name = None
-    _short_name = None
+    _short_name: str | None = None
+    _symbol: str
     _target_currency = None
     _original_currency = None
     _last_available_timer = None
@@ -206,7 +207,7 @@ class YahooFinanceSensor(CoordinatorEntity, SensorEntity):
         if self._short_name is not None:
             # In UK regions, shortName was reported to be the same as symbol.
             # Falling to longName if that is available in that case.
-            if self._short_name == self._symbol:
+            if self._short_name.lower() == self._symbol.lower():
                 if self._long_name is not None:
                     return self._long_name
             else:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -23,6 +23,8 @@ from custom_components.yahoofinance.const import (
     CONF_SYMBOLS,
     DATA_CURRENCY_SYMBOL,
     DATA_DIVIDEND_DATE,
+    DATA_FINANCIAL_CURRENCY,
+    DATA_LONG_NAME,
     DATA_POST_MARKET_TIME,
     DATA_PRE_MARKET_TIME,
     DATA_REGULAR_MARKET_PREVIOUS_CLOSE,
@@ -78,6 +80,7 @@ def build_mock_symbol_data(
     """Build mock data for a symbol."""
     source_data = {
         DATA_CURRENCY_SYMBOL: currency,
+        DATA_LONG_NAME: f"Symbol {symbol} Long",
         DATA_SHORT_NAME: f"Symbol {symbol}",
         DATA_REGULAR_MARKET_PRICE: market_price,
     }
@@ -283,6 +286,36 @@ def test_sensor_data_when_coordinator_returns_none(hass: HomeAssistant) -> None:
     assert sensor.state is None
     # Since we do not have data so the name will be the symbol
     assert sensor.name == symbol
+
+
+def test_sensor_name_when_short_name_is_symbol(hass: HomeAssistant) -> None:
+    """Test sensor status when data coordinator does not have any data."""
+
+    symbol = "0P00008F5Y.L"
+    long_name = f"Symbol {symbol} Long"
+
+    source_data = {
+        DATA_CURRENCY_SYMBOL: "USD",
+        DATA_LONG_NAME: f"Symbol {symbol} Long",
+        DATA_SHORT_NAME: symbol,
+        DATA_REGULAR_MARKET_PRICE: 1.00,
+    }
+    symbol_data = YahooSymbolUpdateCoordinator.parse_symbol_data(source_data)
+
+    mock_coordinator = Mock(
+        data={symbol: symbol_data},
+        hass=hass,
+        last_update_success=False,
+    )
+
+    sensor = YahooFinanceSensor(
+        hass, mock_coordinator, SymbolDefinition(symbol), DEFAULT_OPTIONAL_CONFIG
+    )
+
+    sensor.update_properties()
+
+    assert sensor.available is False
+    assert sensor.name == long_name
 
 
 async def test_sensor_update_calls_coordinator(hass: HomeAssistant) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -23,7 +23,6 @@ from custom_components.yahoofinance.const import (
     CONF_SYMBOLS,
     DATA_CURRENCY_SYMBOL,
     DATA_DIVIDEND_DATE,
-    DATA_FINANCIAL_CURRENCY,
     DATA_LONG_NAME,
     DATA_POST_MARKET_TIME,
     DATA_PRE_MARKET_TIME,
@@ -297,7 +296,7 @@ def test_sensor_name_when_short_name_is_symbol(hass: HomeAssistant) -> None:
     source_data = {
         DATA_CURRENCY_SYMBOL: "USD",
         DATA_LONG_NAME: f"Symbol {symbol} Long",
-        DATA_SHORT_NAME: symbol,
+        DATA_SHORT_NAME: symbol.lower(),
         DATA_REGULAR_MARKET_PRICE: 1.00,
     }
     symbol_data = YahooSymbolUpdateCoordinator.parse_symbol_data(source_data)


### PR DESCRIPTION
The friendly name of an entity comes from shortName. The data returned by Yahoo seems to have the symbol as the shortName for some symbols and mainly in UK region. This PR falls back to longName if it is present and if shortName is the same as the symbol.